### PR TITLE
Features/001 Locate features

### DIFF
--- a/src/romaine/core.py
+++ b/src/romaine/core.py
@@ -6,7 +6,7 @@ class Core(object):
         The core of the Romaine, provides BDD test API.
     """
     # All located features
-    feature_file_paths = []
+    feature_file_paths = set()
     instance = None
 
     def __init__(self):
@@ -43,6 +43,6 @@ class Core(object):
                         )
                     )
 
-        self.feature_file_paths.extend(feature_candidates)
+        self.feature_file_paths.update(feature_candidates)
 
         return feature_candidates

--- a/src/romaine/core.py
+++ b/src/romaine/core.py
@@ -1,6 +1,48 @@
+import os
+
+
 class Core(object):
+    """
+        The core of the Romaine, provides BDD test API.
+    """
+    # All located features
+    feature_file_paths = []
     instance = None
 
     def __init__(self):
+        """
+            Initialise Romaine core.
+        """
         self.steps = {}
         Core.instance = self
+
+    def locate_features(self, path):
+        """
+            Locate any features given a path.
+
+            Keyword arguments:
+            path -- The path to search for features, recursively.
+
+            Returns:
+            List of features located in the path given.
+        """
+        walked_paths = os.walk(path)
+
+        # Features in this path are stored in an intermediate list before
+        # being added to the class variable so that we can return only the
+        # ones we find on this invocation of locate_features
+        feature_candidates = []
+
+        for walked_path in walked_paths:
+            base_directory, sub_directories, feature_files = walked_path
+            for feature_file in feature_files:
+                feature_candidates.append(
+                    os.path.join(
+                        base_directory,
+                        feature_file
+                        )
+                    )
+
+        self.feature_file_paths.extend(feature_candidates)
+
+        return feature_candidates

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+# Allow the tests to work from a tests subdir, then import the test target
+test_path = os.path.dirname(__file__)
+package_directory = os.path.join(os.path.split(test_path)[0], 'src')
+sys.path.append(package_directory)
+
+# Module to be tested
+import romaine  # noqa

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,0 +1,2 @@
+class RunningAsRootError(Exception):
+    pass

--- a/tests/test_locate_features.py
+++ b/tests/test_locate_features.py
@@ -1,6 +1,6 @@
-import nose
-import os
+from tests import common  # noqa
 from tests import exceptions
+import os
 import unittest
 
 
@@ -49,7 +49,7 @@ class TestLocateFeatures(unittest.TestCase):
             # Attempt to remove all the directories we created
             os.removedirs(os.path.join(base_path, 'subdir'))
 
-    def features_found_by_relative_path(self):
+    def test_features_found_by_relative_path(self):
         """
             Check we can find features by a relative path.
         """
@@ -65,7 +65,7 @@ class TestLocateFeatures(unittest.TestCase):
         #   | tests/features/feature1        |
         #   | tests/features/feature2        |
         #   | tests/features/subdir/feature3 |
-        nose.tools.assert_equal(
+        self.assertEqual(
             sorted(results),
             [
                 'tests/features/feature1',
@@ -74,7 +74,7 @@ class TestLocateFeatures(unittest.TestCase):
                 ]
             )
 
-    def features_found_by_absolute_path(self):
+    def test_features_found_by_absolute_path(self):
         """
             Check we can find features by an absolute path.
         """
@@ -90,7 +90,7 @@ class TestLocateFeatures(unittest.TestCase):
         #   | /tmp/romaine_tests/features/feature1        |
         #   | /tmp/romaine_tests/features/feature2        |
         #   | /tmp/romaine_tests/features/subdir/feature3 |
-        nose.tools.assert_equal(
+        self.assertEqual(
             sorted(results),
             [
                 '/tmp/romaine_tests/features/feature1',
@@ -99,7 +99,7 @@ class TestLocateFeatures(unittest.TestCase):
                 ],
             )
 
-    def confirm_features_in_class_variable(self):
+    def test_confirm_features_in_class_variable(self):
         """
             Check feature location populates class features variable.
         """
@@ -120,8 +120,8 @@ class TestLocateFeatures(unittest.TestCase):
         #   | tests/features/feature1                     |
         #   | tests/features/feature2                     |
         #   | tests/features/subdir/feature3              |
-        nose.tools.assert_equal(
-            sorted(core.features),
+        self.assertEqual(
+            sorted(core.feature_file_paths),
             [
                 '/tmp/romaine_tests/features/feature1',
                 '/tmp/romaine_tests/features/feature2',

--- a/tests/test_locate_features.py
+++ b/tests/test_locate_features.py
@@ -1,0 +1,133 @@
+import nose
+import os
+from tests import exceptions
+import unittest
+
+
+class TestLocateFeatures(unittest.TestCase):
+    """
+        Test feature location functionality of romaine's core.
+    """
+    feature_paths = ('tests/features',
+                     '/tmp/romaine_tests/features')
+    features = ('feature1',
+                'feature2',
+                'subdir/feature3')
+
+    def setUp(self):
+        """
+            Prepare the environment for testing.
+        """
+        # Running as root may result in an attempt later to remove /tmp
+        if os.geteuid() == 0:
+            raise exceptions.RunningAsRootError(
+                'Running as root may be harmful, aborting.'
+                )
+
+        for base_path in self.feature_paths:
+            try:
+                os.makedirs(os.path.join(base_path, 'subdir'))
+            except OSError:
+                # Path exists, good.
+                pass
+
+            for feature in self.features:
+                with open(os.path.join(base_path, feature), 'a'):
+                    # We don't need to write anything, just create the file
+                    pass
+
+    def tearDown(self):
+        """
+            Revert changes made during testing.
+        """
+        for base_path in self.feature_paths:
+            # Remove the feature files
+            for feature in self.features:
+                feature = os.path.join(base_path, feature)
+                os.remove(feature)
+
+            # Attempt to remove all the directories we created
+            os.removedirs(os.path.join(base_path, 'subdir'))
+
+    def features_found_by_relative_path(self):
+        """
+            Check we can find features by a relative path.
+        """
+        # Given I have Romaine's core
+        from tests.common import romaine
+        core = romaine.Core()
+
+        # When I locate features in tests/features
+        results = core.locate_features('tests/features')
+
+        # Then I see the list:
+        #   | path                           |
+        #   | tests/features/feature1        |
+        #   | tests/features/feature2        |
+        #   | tests/features/subdir/feature3 |
+        nose.tools.assert_equal(
+            sorted(results),
+            [
+                'tests/features/feature1',
+                'tests/features/feature2',
+                'tests/features/subdir/feature3',
+                ]
+            )
+
+    def features_found_by_absolute_path(self):
+        """
+            Check we can find features by an absolute path.
+        """
+        # Given I have Romaine's core
+        from tests.common import romaine
+        core = romaine.Core()
+
+        # When I locate features in /tmp/romaine_tests/features
+        results = core.locate_features('/tmp/romaine_tests/features')
+
+        # Then I see the list:
+        #   | path                           |
+        #   | /tmp/romaine_tests/features/feature1        |
+        #   | /tmp/romaine_tests/features/feature2        |
+        #   | /tmp/romaine_tests/features/subdir/feature3 |
+        nose.tools.assert_equal(
+            sorted(results),
+            [
+                '/tmp/romaine_tests/features/feature1',
+                '/tmp/romaine_tests/features/feature2',
+                '/tmp/romaine_tests/features/subdir/feature3',
+                ],
+            )
+
+    def confirm_features_in_class_variable(self):
+        """
+            Check feature location populates class features variable.
+        """
+        # Given I have Romaine's core
+        from tests.common import romaine
+        core = romaine.Core()
+
+        # When I locate features in /tmp/romaine_tests/features
+        #  And I locate features in tests/features
+        core.locate_features('/tmp/romaine_tests/features')
+        core.locate_features('tests/features')
+
+        # Then the core's features variable contains:
+        #   | path                                        |
+        #   | /tmp/romaine_tests/features/feature1        |
+        #   | /tmp/romaine_tests/features/feature2        |
+        #   | /tmp/romaine_tests/features/subdir/feature3 |
+        #   | tests/features/feature1                     |
+        #   | tests/features/feature2                     |
+        #   | tests/features/subdir/feature3              |
+        nose.tools.assert_equal(
+            sorted(core.features),
+            [
+                '/tmp/romaine_tests/features/feature1',
+                '/tmp/romaine_tests/features/feature2',
+                '/tmp/romaine_tests/features/subdir/feature3',
+                'tests/features/feature1',
+                'tests/features/feature2',
+                'tests/features/subdir/feature3',
+                ]
+            )

--- a/tests/test_locate_features.py
+++ b/tests/test_locate_features.py
@@ -99,6 +99,27 @@ class TestLocateFeatures(unittest.TestCase):
                 ],
             )
 
+    def test_multiple_calls_no_duplicates(self):
+        """
+            Confirm no duplicates for two calls with the same path.
+        """
+        # Given I have Romaine's core
+        from tests.common import romaine
+        core = romaine.Core()
+
+        # When I locate features in /tmp/romaine_tests/features
+        core.locate_features('/tmp/romaine_tests/features')
+        #  And I locate features in /tmp/romaine_tests/features
+        core.locate_features('/tmp/romaine_tests/features')
+
+        # Then the core's feature_paths_list variable contains no duplicates
+        feature_file_paths = list(core.feature_file_paths)
+        for item in feature_file_paths:
+            self.assertEqual(
+                feature_file_paths.count(item),
+                1,
+                )
+
     def test_confirm_features_in_class_variable(self):
         """
             Check feature location populates class features variable.
@@ -112,7 +133,7 @@ class TestLocateFeatures(unittest.TestCase):
         core.locate_features('/tmp/romaine_tests/features')
         core.locate_features('tests/features')
 
-        # Then the core's features variable contains:
+        # Then the core's feature_paths_list variable contains:
         #   | path                                        |
         #   | /tmp/romaine_tests/features/feature1        |
         #   | /tmp/romaine_tests/features/feature2        |


### PR DESCRIPTION
#1 Add feature finding

``` gherkin
Given that I have features in a path
When I locate features
Then my core has a feature list
```

New PR created to work around merge conflicts.

Regarding whether to put this into core or break it out into its own lib, I think we should keep it in core and only break it out if core becomes unwieldy.

What was your grievance with os.walk? I can't see a better way to do it at the moment without basically reimplementing os.walk in a way that will probably be less readable and have more bugs.

I'm going to create a separate issue for improving tests as there are a couple of irksome points I want to address with them.
